### PR TITLE
Add a module for proving Stable with apalache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         chmod +x tlaps-1.4.5-x86_64-linux-gnu-inst.bin
         ./tlaps-1.4.5-x86_64-linux-gnu-inst.bin -d tlaps
     - name: Run TLAPS
-      run: tlaps/bin/tlapm --cleanfp -I tlaps/ O.tla
+      run: tlaps/bin/tlapm --cleanfp -I tlaps/ O.tla AsyncTerminationDetection_proof.tla
     - name: Get (nightly) TLC
       run: wget https://nightly.tlapl.us/dist/tla2tools.jar
     - name: Run TLC

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@
 __tlacache__
 .tlacache
 
+## Blacklist apalache working dir
+x/
+
 ## Ignore tools installed into the workspace
 tools/

--- a/APAsyncTerminationDetection.cfg
+++ b/APAsyncTerminationDetection.cfg
@@ -1,0 +1,9 @@
+\* 
+\* Check  TypeOK  for an unbounded co-domain of  pending  :
+\* $ apalache-mc check --config=APAsyncTerminationDetection.cfg AsyncTerminationDetection.tla
+\* 
+\* Read https://apalache.informal.systems/docs/adr/002adr-types.html to learn
+\* about Apalache's type annotations.
+CONSTANT N = 3
+SPECIFICATION Spec
+INVARIANT TypeOK

--- a/AsyncTerminationDetection.tla
+++ b/AsyncTerminationDetection.tla
@@ -15,7 +15,9 @@ EXTENDS Naturals
  \* * syntactically correct.  However, we don't know what elements are in the sets 
  \* * 23 and "frob" (nor do we care). The value of 23="frob" is undefined, and TLA+
  \* * users call this a "silly expression".
-CONSTANT N
+CONSTANT 
+    \* @type: Int;
+    N
 
 \* * It's a good idea to tell readers of the spec what value we assume of constants
  \* * In this spec, we assume constant N to be a (positive) natural number, by
@@ -37,7 +39,9 @@ Node == 0 .. N-1                           \* == pp'ed as ≜
  \* * while pending counts the in-flight messages from other nodes that a
  \* * node has yet to receive.
 VARIABLES 
+  \* @type: Int -> Bool;
   active,               \* activation status of nodes
+  \* @type: Int -> Int;
   pending,              \* number of messages pending at a node
   \* * Up to now, this specification didn't teach us anything useful regarding
    \* * termination detection in a ring (we were mostly concerned with TLA+ itself).
@@ -51,6 +55,7 @@ VARIABLES
    \* * For termination detection, the complete history of the computation, performed
    \* * by the system, is not relevant--we only care if the system detected
    \* * termination.
+  \* @type: Bool;
   terminationDetected
 
 \* * A definition that lets us refer to the spec's variables (more on it later).

--- a/AsyncTerminationDetection_apalache.tla
+++ b/AsyncTerminationDetection_apalache.tla
@@ -1,0 +1,55 @@
+---------------------- MODULE AsyncTerminationDetection_apalache ---------------
+\* This module contains special setup for Apalache.
+
+\* Fix the number of nodes, as Apalache works with bounded sets
+N == 20
+
+\* A copy of variables from AsyncTerminationDetection,
+\* in order to define an instance
+VARIABLES 
+  \* @type: Int -> Bool;
+  active,
+  \* @type: Int -> Int;
+  pending,
+  \* @type: Bool;
+  terminationDetected
+
+\* Introduce an instance with N fixed
+INSTANCE AsyncTerminationDetection
+
+\* We want to prove the temporal property Stable, which is defined as:
+\*
+\* Stable == [](terminationDetected => []terminated)
+\*
+\* For the moment, Apalache supports only invariant checking.
+\* Nevertheless, we can prove the property Stable with Apalache.
+\* If we look carefully at the temporal formula Stable,
+\* we can see that it is sufficient to prove the following:
+\*
+\* 1. Init => StableInv
+\* 2. StableInv /\ Next => StableInv'
+\* 3. StableInv /\ Next => StableActionInv
+\*
+\* We can check that by issuing the following three queries:
+\*
+\* $ apalache-mc check --init=Init --inv=StableInv --length=1 \
+\*    AsyncTerminationDetection_apalache.tla
+\* $ apalache-mc check --init=StableInv --inv=StableInv --length=2 \
+\*    AsyncTerminationDetection_apalache.tla
+\* $ apalache-mc check --init=StableInv --inv=StableActionInv --length=2 \
+\*    AsyncTerminationDetection_apalache.tla
+\*
+\* We issue query 1 for a computation of length 1
+\* (predicate Init is counted as a step),
+\* whereas we issue queries 2-3 for computations of length 2
+\* (StableInv, then Next).
+
+\* This is a state invariant.
+StableInv ==
+    /\ TypeOK
+    /\ (terminationDetected => terminated)
+
+\* This is an action invariant.
+StableActionInv ==    
+    terminated => terminated'
+=============================================================================

--- a/AsyncTerminationDetection_proof.tla
+++ b/AsyncTerminationDetection_proof.tla
@@ -1,18 +1,17 @@
 ---------------------- MODULE AsyncTerminationDetection_proof ---------------------
 EXTENDS AsyncTerminationDetection, TLAPS
 
-(* Whitelist all the known facts/assumptions and definitions *)
-USE NIsPosNat DEF vars, terminated, Node,
-                  Init, Next, Spec,
-                  DetectTermination, Terminate,
-                  Wakeup, SendMsg,
-                  TypeOK, Stable
+(* Do not whitelist all the known facts/assumptions and definitions to speedup provers *)
+\*USE NIsPosNat DEF vars, terminated, Node,
+\*                  Init, Next, Spec,
+\*                  DetectTermination, Terminate,
+\*                  Wakeup, SendMsg,
+\*                  TypeOK, Stable
 
 \* * An invariant I is inductive, iff Init => I and I /\ [Next]_vars => I. Note
 \* * though, that TypeOK itself won't imply  Stable  though!  TypeOK alone
 \* * does not help us prove Stable.
 
-\* TODO Prove  TypeOK  inductive.
 LEMMA TypeCorrect == Spec => []TypeOK
 <1>1. Init => TypeOK BY NIsPosNat DEF Init, TypeOK, Node, terminated
 <1>2. TypeOK /\ [Next]_vars => TypeOK'
@@ -21,26 +20,29 @@ LEMMA TypeCorrect == Spec => []TypeOK
               PROVE  TypeOK'
    OBVIOUS
  <2>1. CASE DetectTermination
-   BY <2>1
+   BY <2>1 DEF TypeOK, Next, vars, DetectTermination
  <2>2. ASSUME NEW i \in Node,
               NEW j \in Node,
               Terminate(i)
        PROVE  TypeOK'
-   BY <2>2
+   BY <2>2 DEF TypeOK, Next, vars, Terminate, terminated
  <2>3. ASSUME NEW i \in Node,
               NEW j \in Node,
               Wakeup(i)
        PROVE  TypeOK'
-   BY <2>3
+   BY <2>3 DEF TypeOK, Next, vars, Wakeup
  <2>4. ASSUME NEW i \in Node,
               NEW j \in Node,
               SendMsg(i, j)
        PROVE  TypeOK'
-   BY <2>4
+   BY <2>4 DEF TypeOK, Next, vars, SendMsg
  <2>5. CASE UNCHANGED vars
-   BY <2>5
+   BY <2>5 DEF TypeOK, Next, vars
  <2>6. QED
    BY <2>1, <2>2, <2>3, <2>4, <2>5 DEF Next
-<1>. QED BY <1>1, <1>2, PTL
+<1>. QED BY <1>1, <1>2, PTL DEF Spec
+
+\* ? How do we prove   Spec => Stable  ?
+ \* ? We would have to find an inductive invariant that implies  Stable  .
 
 =============================================================================

--- a/AsyncTerminationDetection_proof.tla
+++ b/AsyncTerminationDetection_proof.tla
@@ -3,7 +3,7 @@ EXTENDS AsyncTerminationDetection, TLAPS
 
 (* Whitelist all the known facts/assumptions and definitions *)
 USE NIsPosNat DEF vars, terminated, Node,
-                  Init, Next,
+                  Init, Next, Spec,
                   DetectTermination, Terminate,
                   Wakeup, SendMsg,
                   TypeOK, Stable
@@ -13,6 +13,9 @@ USE NIsPosNat DEF vars, terminated, Node,
 \* * does not help us prove Stable.
 
 \* TODO Prove  TypeOK  inductive.
-LEMMA TypeCorrect == Spec => []TypeOK  OBVIOUS 
+LEMMA TypeCorrect == Spec => []TypeOK
+<1>1. Init => TypeOK  OBVIOUS 
+<1>2. TypeOK /\ [Next]_vars => TypeOK' 
+<1>. QED BY <1>1, <1>2, PTL
 
 =============================================================================

--- a/AsyncTerminationDetection_proof.tla
+++ b/AsyncTerminationDetection_proof.tla
@@ -43,6 +43,17 @@ LEMMA TypeCorrect == Spec => []TypeOK
 <1>. QED BY <1>1, <1>2, PTL DEF Spec
 
 \* ? How do we prove   Spec => Stable  ?
- \* ? We would have to find an inductive invariant that implies  Stable  .
+ \* ? We would have to find an inductive invariant  IInv  that implies  Stable  ,
+ \* ? (unless  Stable  happens to be inductive).  Usually, we start with  TypeOK
+ \* ? and conjoin additional constraints.  The proof then is as follows:
+IInv ==
+    /\ TypeOK
+    /\ TRUE \* The additional constraints here.
+
+THEOREM Termination == Spec => Stable
+<1>1. Init => IInv
+<1>2. IInv /\ [Next]_vars => IInv'
+<1>3. IInv => Stable
+<1>. QED BY <1>1, <1>2, <1>3 DEF Spec, Stable
 
 =============================================================================

--- a/AsyncTerminationDetection_proof.tla
+++ b/AsyncTerminationDetection_proof.tla
@@ -14,7 +14,7 @@ USE NIsPosNat DEF vars, terminated, Node,
 
 \* TODO Prove  TypeOK  inductive.
 LEMMA TypeCorrect == Spec => []TypeOK
-<1>1. Init => TypeOK  OBVIOUS 
+<1>1. Init => TypeOK BY NIsPosNat DEF Init, TypeOK, Node, terminated
 <1>2. TypeOK /\ [Next]_vars => TypeOK' 
 <1>. QED BY <1>1, <1>2, PTL
 

--- a/AsyncTerminationDetection_proof.tla
+++ b/AsyncTerminationDetection_proof.tla
@@ -1,0 +1,18 @@
+---------------------- MODULE AsyncTerminationDetection_proof ---------------------
+EXTENDS AsyncTerminationDetection, TLAPS
+
+(* Whitelist all the known facts/assumptions and definitions *)
+USE NIsPosNat DEF vars, terminated, Node,
+                  Init, Next,
+                  DetectTermination, Terminate,
+                  Wakeup, SendMsg,
+                  TypeOK, Stable
+
+\* * An invariant I is inductive, iff Init => I and I /\ [Next]_vars => I. Note
+\* * though, that TypeOK itself won't imply  Stable  though!  TypeOK alone
+\* * does not help us prove Stable.
+
+\* TODO Prove  TypeOK  inductive.
+LEMMA TypeCorrect == Spec => []TypeOK  OBVIOUS 
+
+=============================================================================

--- a/AsyncTerminationDetection_proof.tla
+++ b/AsyncTerminationDetection_proof.tla
@@ -15,7 +15,7 @@ USE NIsPosNat DEF vars, terminated, Node,
 \* TODO Prove  TypeOK  inductive.
 LEMMA TypeCorrect == Spec => []TypeOK
 <1>1. Init => TypeOK BY NIsPosNat DEF Init, TypeOK, Node, terminated
-<1>2. TypeOK /\ [Next]_vars => TypeOK' 
+<1>2. TypeOK /\ [Next]_vars => TypeOK'  OBVIOUS 
 <1>. QED BY <1>1, <1>2, PTL
 
 =============================================================================

--- a/AsyncTerminationDetection_proof.tla
+++ b/AsyncTerminationDetection_proof.tla
@@ -15,7 +15,32 @@ USE NIsPosNat DEF vars, terminated, Node,
 \* TODO Prove  TypeOK  inductive.
 LEMMA TypeCorrect == Spec => []TypeOK
 <1>1. Init => TypeOK BY NIsPosNat DEF Init, TypeOK, Node, terminated
-<1>2. TypeOK /\ [Next]_vars => TypeOK'  OBVIOUS 
+<1>2. TypeOK /\ [Next]_vars => TypeOK'
+ <2> SUFFICES ASSUME TypeOK,
+                     [Next]_vars
+              PROVE  TypeOK'
+   OBVIOUS
+ <2>1. CASE DetectTermination
+   BY <2>1
+ <2>2. ASSUME NEW i \in Node,
+              NEW j \in Node,
+              Terminate(i)
+       PROVE  TypeOK'
+   BY <2>2
+ <2>3. ASSUME NEW i \in Node,
+              NEW j \in Node,
+              Wakeup(i)
+       PROVE  TypeOK'
+   BY <2>3
+ <2>4. ASSUME NEW i \in Node,
+              NEW j \in Node,
+              SendMsg(i, j)
+       PROVE  TypeOK'
+   BY <2>4
+ <2>5. CASE UNCHANGED vars
+   BY <2>5
+ <2>6. QED
+   BY <2>1, <2>2, <2>3, <2>4, <2>5 DEF Next
 <1>. QED BY <1>1, <1>2, PTL
 
 =============================================================================


### PR DESCRIPTION
This PR introduces `AsyncTerminationDetection_apalache.tla` that you can use to prove the property `Stable` with Apalache for `N=20`.